### PR TITLE
Avoid leaving residual of secrets at print

### DIFF
--- a/flask_unsign/cracker.py
+++ b/flask_unsign/cracker.py
@@ -79,7 +79,7 @@ class Cracker:
 
                 print((
                     f"[*] Attempted ({self.attempts}): "
-                    f"{secret[0:30].decode('ascii', errors='ignore').ljust(30, ' ')}".strip()
+                    f"{secret[0:30].decode('ascii', errors='ignore').ljust(30, ' ')}"
                 ), end='\r', flush=True, file=sys.stderr)
 
             self.lock.release()


### PR DESCRIPTION
Hi,

Just a little cosmetic improvement:

* The curent secret is `grangemouth` and `kvenstoideo` is  mix of residuals
```
$ flask-unsign --unsign --cookie $COOKIE --wordlist rockyou.txt --no-literal-eval
[*] Session decodes to: {'admin': 'false', 'username': 'guest'}
[*] Starting brute-forcer with 8 threads..
[*] Attempted (243968): grangemouthkvenstoideo
```
* With `.strip()` removed:
```
$ flask-unsign --unsign --cookie $COOKIE --wordlist rockyou.txt --no-literal-eval
[*] Session decodes to: {'admin': 'false', 'username': 'guest'}
[*] Starting brute-forcer with 8 threads..
[*] Attempted (243968): grangemouth
```
