### PR TITLE
Fixed issue #17

### DIFF
--- a/flask_unsign/__main__.py
+++ b/flask_unsign/__main__.py
@@ -184,7 +184,7 @@ def main() -> Optional[int]:
         args.cookie = sys.stdin.read().strip()
 
     if args.sign:
-        if not args.secret:
+        if not type(args.secret) is str:
             return logger.error('Missing required parameter "--secret".')
 
         if not args.cookie:


### PR DESCRIPTION
Modified  `--secret` parameter handler. It will check if `args.secret` get empty `string` or `None` type, if there is not `--secret` parameter(`None`) it will rise the error:
`[!] Missing required parameter "--secret".`